### PR TITLE
Maryia/positions-redesign/test: ContractCardList, ContractCardStatusTimer, PositionsStore, getCurrentTick() + refactoring

### DIFF
--- a/packages/shared/src/utils/contract/__tests__/contract.spec.ts
+++ b/packages/shared/src/utils/contract/__tests__/contract.spec.ts
@@ -786,3 +786,76 @@ describe('isForwardStartingBuyTransaction', () => {
         ).toBe(false);
     });
 });
+
+describe('getCurrentTick', () => {
+    const tickStreamWithFourTicks = [
+        {
+            epoch: 1716910930,
+            tick: 1338.44,
+            tick_display_value: '1338.44',
+        },
+        {
+            epoch: 1716910932,
+            tick: 1338.71,
+            tick_display_value: '1338.71',
+        },
+        {
+            epoch: 1716910934,
+            tick: 1338.69,
+            tick_display_value: '1338.69',
+        },
+        {
+            epoch: 1716910936,
+            tick: 1338.94,
+            tick_display_value: '1338.94',
+        },
+    ];
+    it('should return tick_passed if tick_passed is available for a non-digit/non-asian contract', () => {
+        const mockedAccuContractInfo = mockContractInfo({
+            contract_type: CONTRACT_TYPES.ACCUMULATOR,
+            tick_passed: 2,
+        });
+        expect(ContractUtils.getCurrentTick(mockedAccuContractInfo)).toEqual(2);
+    });
+    it('should return tick_stream.length - 1 if tick_passed is missing for a non-digit/non-asian contract', () => {
+        const mockedRiseContractInfo = mockContractInfo({
+            contract_type: CONTRACT_TYPES.RISE,
+            tick_stream: tickStreamWithFourTicks,
+        });
+        expect(ContractUtils.getCurrentTick(mockedRiseContractInfo)).toEqual(3);
+    });
+    it('should return tick_stream.length for a digit/asian contract', () => {
+        const mockedDigitContractInfo = mockContractInfo({
+            contract_type: CONTRACT_TYPES.MATCH_DIFF.MATCH,
+            tick_stream: tickStreamWithFourTicks,
+        });
+        const mockedAsianContractInfo = mockContractInfo({
+            contract_type: CONTRACT_TYPES.ASIAN.UP,
+            tick_stream: tickStreamWithFourTicks,
+        });
+        expect(ContractUtils.getCurrentTick(mockedDigitContractInfo)).toEqual(4);
+        expect(ContractUtils.getCurrentTick(mockedAsianContractInfo)).toEqual(4);
+    });
+    it('should return 0 if tick_stream is empty/missing for a digit/asian contract', () => {
+        const mockedDigitContractInfo = mockContractInfo({
+            contract_type: CONTRACT_TYPES.MATCH_DIFF.MATCH,
+        });
+        const mockedAsianContractInfo = mockContractInfo({
+            contract_type: CONTRACT_TYPES.ASIAN.UP,
+            tick_stream: [],
+        });
+        expect(ContractUtils.getCurrentTick(mockedDigitContractInfo)).toEqual(0);
+        expect(ContractUtils.getCurrentTick(mockedAsianContractInfo)).toEqual(0);
+    });
+    it('should return 0 if both tick_stream and tick_passed are empty/missing for a non-digit/non-asian contract', () => {
+        const mockedAccuContractInfo = mockContractInfo({
+            contract_type: CONTRACT_TYPES.ACCUMULATOR,
+        });
+        const mockedRiseContractInfo = mockContractInfo({
+            contract_type: CONTRACT_TYPES.RISE,
+            tick_stream: [],
+        });
+        expect(ContractUtils.getCurrentTick(mockedAccuContractInfo)).toEqual(0);
+        expect(ContractUtils.getCurrentTick(mockedRiseContractInfo)).toEqual(0);
+    });
+});

--- a/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card-list.spec.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card-list.spec.tsx
@@ -11,12 +11,12 @@ const cancelButton = 'Cancel';
 const closeButton = 'Close';
 
 jest.mock('../contract-card', () =>
-    jest.fn((props: React.ComponentProps<typeof ContractCard>) => (
+    jest.fn(({ onCancel, onClose }: React.ComponentProps<typeof ContractCard>) => (
         <div>
             {contractCard}
             <>
-                <button onClick={props.onCancel}>{cancelButton}</button>
-                <button onClick={props.onClose}>{closeButton}</button>
+                <button onClick={onCancel}>{cancelButton}</button>
+                <button onClick={onClose}>{closeButton}</button>
             </>
         </div>
     ))

--- a/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card-list.spec.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card-list.spec.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { mockContractInfo } from '@deriv/shared';
+import ContractCardList from '../contract-card-list';
+import { TPortfolioPosition } from '@deriv/stores/types';
+
+const ContractCard = 'Contract Card';
+
+jest.mock('../contract-card', () => jest.fn(() => <div>{ContractCard}</div>));
+
+const mockProps: React.ComponentProps<typeof ContractCardList> = {
+    positions: [
+        {
+            contract_info: mockContractInfo({
+                contract_id: 243585717228,
+            }),
+        },
+        {
+            contract_info: mockContractInfo({
+                contract_id: 243578583348,
+            }),
+        },
+    ] as TPortfolioPosition[],
+};
+
+describe('ContractCardList', () => {
+    it('should not render component if positions are empty/not passed', () => {
+        const { container } = render(<ContractCardList />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+    it('should render component if positions are not empty', () => {
+        render(<ContractCardList {...mockProps} />);
+
+        expect(screen.getAllByText(ContractCard)).toHaveLength(2);
+    });
+    it('should call setHasButtonsDemo with false after 720ms if hasButtonsDemo === true', () => {
+        const mockedSetHasButtonsDemo = jest.fn();
+        jest.useFakeTimers();
+        render(<ContractCardList {...mockProps} hasButtonsDemo setHasButtonsDemo={mockedSetHasButtonsDemo} />);
+
+        jest.advanceTimersByTime(720);
+        expect(mockedSetHasButtonsDemo).toHaveBeenCalledWith(false);
+    });
+});

--- a/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card-list.spec.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card-list.spec.tsx
@@ -1,12 +1,26 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TPortfolioPosition } from '@deriv/stores/types';
 import { mockContractInfo } from '@deriv/shared';
 import ContractCardList from '../contract-card-list';
-import { TPortfolioPosition } from '@deriv/stores/types';
+import ContractCard from '../contract-card';
 
-const ContractCard = 'Contract Card';
+const contractCard = 'Contract Card';
+const cancelButton = 'Cancel';
+const closeButton = 'Close';
 
-jest.mock('../contract-card', () => jest.fn(() => <div>{ContractCard}</div>));
+jest.mock('../contract-card', () =>
+    jest.fn((props: React.ComponentProps<typeof ContractCard>) => (
+        <div>
+            {contractCard}
+            <>
+                <button onClick={props.onCancel}>{cancelButton}</button>
+                <button onClick={props.onClose}>{closeButton}</button>
+            </>
+        </div>
+    ))
+);
 
 const mockProps: React.ComponentProps<typeof ContractCardList> = {
     positions: [
@@ -32,7 +46,7 @@ describe('ContractCardList', () => {
     it('should render component if positions are not empty', () => {
         render(<ContractCardList {...mockProps} />);
 
-        expect(screen.getAllByText(ContractCard)).toHaveLength(2);
+        expect(screen.getAllByText(contractCard)).toHaveLength(2);
     });
     it('should call setHasButtonsDemo with false after 720ms if hasButtonsDemo === true', () => {
         const mockedSetHasButtonsDemo = jest.fn();
@@ -41,5 +55,21 @@ describe('ContractCardList', () => {
 
         jest.advanceTimersByTime(720);
         expect(mockedSetHasButtonsDemo).toHaveBeenCalledWith(false);
+    });
+    it('should call onClickCancel with contract_id when a Cancel button is clicked on a contract card', () => {
+        const mockedOnClickCancel = jest.fn();
+        render(<ContractCardList {...mockProps} onClickCancel={mockedOnClickCancel} />);
+
+        const firstCardCancelButton = screen.getAllByText(cancelButton)[0];
+        userEvent.click(firstCardCancelButton);
+        expect(mockedOnClickCancel).toHaveBeenCalledWith(243585717228);
+    });
+    it('should call onClickSell with contract_id when a Close button is clicked on a contract card', () => {
+        const mockedOnClickSell = jest.fn();
+        render(<ContractCardList {...mockProps} onClickSell={mockedOnClickSell} />);
+
+        const secondCardCloseButton = screen.getAllByText(closeButton)[1];
+        userEvent.click(secondCardCloseButton);
+        expect(mockedOnClickSell).toHaveBeenCalledWith(243578583348);
     });
 });

--- a/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card-status-timer.spec.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card-status-timer.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { getCardLabels, toMoment } from '@deriv/shared';
+import { ContractCardStatusTimer } from '../contract-card-status-timer';
+
+describe('ContractCardStatusTimer', () => {
+    const mockProps = { date_expiry: Date.now() / 1000 + 1000 };
+    it('should render Closed status if date_expiry is not passed', () => {
+        render(<ContractCardStatusTimer />);
+
+        expect(screen.getByText(getCardLabels().CLOSED)).toBeInTheDocument();
+    });
+    it('should not render the component if date_expiry is passed without serverTime and no other props are passed', () => {
+        const { container } = render(<ContractCardStatusTimer {...mockProps} />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+    it('should render remaining time if date_expiry and serverTime are passed', () => {
+        render(<ContractCardStatusTimer {...mockProps} serverTime={toMoment(Date.now() / 1000)} />);
+
+        expect(screen.getByText('00:16:40')).toBeInTheDocument();
+    });
+    it('should render ticks progress if currentTick and tick_count are passed', () => {
+        render(<ContractCardStatusTimer {...mockProps} currentTick={2} tick_count={10} />);
+
+        expect(screen.getByText('2/10 ticks')).toBeInTheDocument();
+    });
+    it('should render Ongoing status if hasNoAutoExpiry === true', () => {
+        render(<ContractCardStatusTimer {...mockProps} hasNoAutoExpiry />);
+
+        expect(screen.getByText('Ongoing')).toBeInTheDocument();
+    });
+    it('should render Closed status if isSold === true', () => {
+        render(<ContractCardStatusTimer {...mockProps} isSold />);
+
+        expect(screen.getByText(getCardLabels().CLOSED)).toBeInTheDocument();
+    });
+});

--- a/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card.spec.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card.spec.tsx
@@ -345,7 +345,7 @@ describe('ContractCard', () => {
         expect(screen.getByRole('button', { name: CANCEL })).toBeEnabled();
         expect(screen.getByRole('button', { name: CLOSE })).toBeDisabled();
     });
-    it('should render a card for an open Accumulators position with a Close button only and remaining number of ticks', () => {
+    it('should render a card for an open Accumulators position with a Close button only and ticks progress', () => {
         render(
             mockedContractCard({
                 ...mockProps,

--- a/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card.spec.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card.spec.tsx
@@ -306,6 +306,7 @@ describe('ContractCard', () => {
         currency: 'USD',
         hasActionButtons: true,
         isSellRequested: false,
+        redirectTo: getContractPath(openPositions[0].contract_info.contract_id),
         serverTime: toMoment(Date.now() / 1000),
     };
     const mockedContractCard = (props = mockProps) => (
@@ -315,7 +316,7 @@ describe('ContractCard', () => {
     );
 
     it('should not render component if contractInfo prop is empty/missing contract_type', () => {
-        const { container } = render(mockedContractCard({ contractInfo: {} }));
+        const { container } = render(mockedContractCard({ ...mockProps, contractInfo: {} }));
 
         expect(container).toBeEmptyDOMElement();
     });

--- a/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-cards-sections.spec.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-cards-sections.spec.tsx
@@ -7,7 +7,6 @@ const ContractCard = 'Contract Card';
 jest.mock('../contract-card', () => jest.fn(() => <div>{ContractCard}</div>));
 
 const mockProps = {
-    onScroll: jest.fn(),
     positions: [
         {
             contract_info: {

--- a/packages/trader/src/AppV2/Components/ContractCard/contract-card-list.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/contract-card-list.tsx
@@ -17,16 +17,18 @@ export type TContractCardListProps = {
 };
 
 const ContractCardList = ({
-    currency,
     hasButtonsDemo,
     onClickCancel,
     onClickSell,
     positions = [],
-    serverTime,
     setHasButtonsDemo,
+    ...rest
 }: TContractCardListProps) => {
     React.useEffect(() => {
-        const demoTimeout = setTimeout(() => setHasButtonsDemo?.(false), 720); // 720 is the length of demo animation
+        let demoTimeout: ReturnType<typeof setTimeout>;
+        if (hasButtonsDemo && setHasButtonsDemo) {
+            demoTimeout = setTimeout(() => setHasButtonsDemo(false), 720); // 720 is the length of demo animation
+        }
         return () => {
             if (demoTimeout) clearTimeout(demoTimeout);
         };
@@ -46,13 +48,12 @@ const ContractCardList = ({
                     <ContractCard
                         key={id}
                         contractInfo={position.contract_info}
-                        currency={currency}
                         hasActionButtons={!!onClickSell}
                         isSellRequested={(position as TPortfolioPosition).is_sell_requested}
                         onCancel={() => id && onClickCancel?.(id)}
                         onClose={() => id && onClickSell?.(id)}
-                        redirectTo={id ? getContractPath(id) : undefined}
-                        serverTime={serverTime}
+                        redirectTo={getContractPath(Number(id))}
+                        {...rest}
                     />
                 );
             })}

--- a/packages/trader/src/AppV2/Components/ContractCard/contract-card-status-timer.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/contract-card-status-timer.tsx
@@ -27,25 +27,30 @@ export const ContractCardStatusTimer = ({
         if (tick_count) {
             return `${currentTick ?? 0}/${tick_count} ${getCardLabels().TICKS.toLowerCase()}`;
         }
-        return (
-            <RemainingTime
-                as='span'
-                end_time={date_expiry}
-                getCardLabels={getCardLabels}
-                start_time={serverTime as moment.Moment}
-            />
-        );
+        if (date_expiry && serverTime) {
+            return (
+                <RemainingTime
+                    as='span'
+                    end_time={date_expiry}
+                    getCardLabels={getCardLabels}
+                    start_time={serverTime as moment.Moment}
+                />
+            );
+        }
+        return null;
     };
-    if (!date_expiry || (serverTime as moment.Moment).unix() > +date_expiry || isSold) {
+    const displayedDuration = getDisplayedDuration();
+
+    if (!date_expiry || (serverTime as moment.Moment)?.unix() > +date_expiry || isSold) {
         return <Tag className='status' label={getCardLabels().CLOSED} variant='custom' color='custom' size='sm' />;
     }
-    return (
+    return displayedDuration ? (
         <Tag
             className='timer'
             icon={<LabelPairedStopwatchCaptionRegularIcon />}
-            label={getDisplayedDuration()}
+            label={displayedDuration}
             variant='custom'
             size='sm'
         />
-    );
+    ) : null;
 };

--- a/packages/trader/src/AppV2/Components/ContractCard/contract-card.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/contract-card.tsx
@@ -30,7 +30,7 @@ type TContractCardProps = TContractCardStatusTimerProps & {
     onClick?: (e?: React.MouseEvent<HTMLAnchorElement>) => void;
     onCancel?: (e?: React.MouseEvent<HTMLButtonElement>) => void;
     onClose?: (e?: React.MouseEvent<HTMLButtonElement>) => void;
-    redirectTo?: string;
+    redirectTo: string;
     serverTime?: TRootStore['common']['server_time'];
 };
 

--- a/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
+++ b/packages/trader/src/AppV2/Components/Filter/contract-type-filter.tsx
@@ -8,7 +8,7 @@ type TContractTypeFilter = {
     setContractTypeFilter: (filterValues: string[]) => void;
 };
 
-const mockAvailableContractsList = [
+const availableContracts = [
     { tradeType: <Localize i18n_default_text='Accumulators' />, id: 'Accumulators' },
     { tradeType: <Localize i18n_default_text='Vanillas' />, id: 'Vanillas' },
     { tradeType: <Localize i18n_default_text='Turbos' />, id: 'Turbos' },
@@ -43,8 +43,7 @@ const ContractTypeFilter = ({ contractTypeFilter, setContractTypeFilter }: TCont
     const chipLabelFormatting = () => {
         const arrayLength = contractTypeFilter.length;
         if (!arrayLength) return <Localize i18n_default_text='All trade types' />;
-        if (arrayLength === 1)
-            return mockAvailableContractsList.find(type => type.id === contractTypeFilter[0])?.tradeType;
+        if (arrayLength === 1) return availableContracts.find(type => type.id === contractTypeFilter[0])?.tradeType;
         return <Localize i18n_default_text='{{amount}} trade types' values={{ amount: arrayLength }} />;
     };
 
@@ -62,7 +61,7 @@ const ContractTypeFilter = ({ contractTypeFilter, setContractTypeFilter }: TCont
                 <ActionSheet.Portal shouldCloseOnDrag>
                     <ActionSheet.Header title={<Localize i18n_default_text='Filter by trade types' />} />
                     <ActionSheet.Content className='filter__item__wrapper'>
-                        {mockAvailableContractsList.map(({ tradeType, id }) => (
+                        {availableContracts.map(({ tradeType, id }) => (
                             <Checkbox
                                 checked={changedOptions.includes(id)}
                                 checkboxPosition='right'

--- a/packages/trader/src/Stores/Modules/Positions/__tests__/positions-store.spec.ts
+++ b/packages/trader/src/Stores/Modules/Positions/__tests__/positions-store.spec.ts
@@ -1,0 +1,49 @@
+import { mockStore } from '@deriv/stores';
+import PositionsStore from '../positions-store';
+import { configure } from 'mobx';
+import { TRootStore } from 'Types';
+
+configure({ safeDescriptors: false });
+
+let mockedPositionsStore: PositionsStore;
+
+beforeAll(async () => {
+    mockedPositionsStore = new PositionsStore({
+        root_store: mockStore({}) as unknown as TRootStore,
+    });
+});
+
+describe('PositionsStore', () => {
+    describe('setClosedContractTypeFilter', () => {
+        it('should set closedContractTypeFilter', () => {
+            mockedPositionsStore.setClosedContractTypeFilter(['Accumulators']);
+            expect(mockedPositionsStore.closedContractTypeFilter).toEqual(['Accumulators']);
+            mockedPositionsStore.setClosedContractTypeFilter([]);
+            expect(mockedPositionsStore.closedContractTypeFilter).toEqual([]);
+        });
+    });
+    describe('setOpenContractTypeFilter', () => {
+        it('should set openContractTypeFilter', () => {
+            mockedPositionsStore.setOpenContractTypeFilter(['Rise/Fall']);
+            expect(mockedPositionsStore.openContractTypeFilter).toEqual(['Rise/Fall']);
+            mockedPositionsStore.setOpenContractTypeFilter([]);
+            expect(mockedPositionsStore.openContractTypeFilter).toEqual([]);
+        });
+    });
+    describe('setTimeFilter', () => {
+        it('should set timeFilter', () => {
+            mockedPositionsStore.setTimeFilter('All time');
+            expect(mockedPositionsStore.timeFilter).toEqual('All time');
+            mockedPositionsStore.setTimeFilter();
+            expect(mockedPositionsStore.timeFilter).toEqual('');
+        });
+    });
+    describe('setCustomTimeRangeFilter', () => {
+        it('should set customTimeRangeFilter', () => {
+            mockedPositionsStore.setCustomTimeRangeFilter('25 May 2024');
+            expect(mockedPositionsStore.customTimeRangeFilter).toEqual('25 May 2024');
+            mockedPositionsStore.setCustomTimeRangeFilter();
+            expect(mockedPositionsStore.customTimeRangeFilter).toEqual('');
+        });
+    });
+});


### PR DESCRIPTION
## Changes:

- add unit-tests for: ContractCardList, ContractCardStatusTimer, PositionsStore, getCurrentTick() helper 
- refactoring

Coverage:
<img width="944" alt="Screenshot 2024-05-28 at 8 56 14 PM" src="https://github.com/kate-deriv/deriv-app/assets/103177211/be6d6da1-9ef5-4d7f-9d1f-37dd4a12f8bd">
<img width="737" alt="Screenshot 2024-05-28 at 7 14 33 PM" src="https://github.com/kate-deriv/deriv-app/assets/103177211/9afc0802-55e0-4344-b37a-1961fc148c12">
<img width="944" alt="Screenshot 2024-05-28 at 9 02 59 PM" src="https://github.com/kate-deriv/deriv-app/assets/103177211/9a55dc10-c7e5-4a2d-b919-064a9537daa0">
