### PR TITLE
Maryia/positions-redesign/fix: loader on infinite scroll in Closed tab + make redirectTo prop optional in ContractCard

### DIFF
--- a/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card-status-timer.spec.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card-status-timer.spec.tsx
@@ -3,8 +3,10 @@ import { render, screen } from '@testing-library/react';
 import { getCardLabels, toMoment } from '@deriv/shared';
 import { ContractCardStatusTimer } from '../contract-card-status-timer';
 
+const mockedNow = Math.floor(Date.now() / 1000);
+
 describe('ContractCardStatusTimer', () => {
-    const mockProps = { date_expiry: Date.now() / 1000 + 1000 };
+    const mockProps = { date_expiry: mockedNow + 1000 };
     it('should render Closed status if date_expiry is not passed', () => {
         render(<ContractCardStatusTimer />);
 
@@ -16,7 +18,7 @@ describe('ContractCardStatusTimer', () => {
         expect(container).toBeEmptyDOMElement();
     });
     it('should render remaining time if date_expiry and serverTime are passed', () => {
-        render(<ContractCardStatusTimer {...mockProps} serverTime={toMoment(Date.now() / 1000)} />);
+        render(<ContractCardStatusTimer {...mockProps} serverTime={toMoment(mockedNow)} />);
 
         expect(screen.getByText('00:16:40')).toBeInTheDocument();
     });

--- a/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card.spec.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/__tests__/contract-card.spec.tsx
@@ -8,6 +8,8 @@ import { TPortfolioPosition } from '@deriv/stores/types';
 import { TClosedPosition } from 'AppV2/Containers/Positions/positions-content';
 import ContractCard from '../contract-card';
 
+const mockedNow = Math.floor(Date.now() / 1000);
+
 const closedPositions = [
     {
         contract_info: {
@@ -46,8 +48,8 @@ const openPositions = [
             current_spot: 681.76,
             current_spot_display_value: '681.76',
             current_spot_time: 1716220628,
-            date_expiry: Date.now() / 1000 + 1000,
-            date_settlement: Date.now() / 1000 + 1000,
+            date_expiry: mockedNow + 1000,
+            date_settlement: mockedNow + 1000,
             date_start: 1716220562,
             display_name: 'Volatility 100 (1s) Index',
             entry_spot: 682.6,
@@ -55,7 +57,7 @@ const openPositions = [
             entry_tick: 682.6,
             entry_tick_display_value: '682.60',
             entry_tick_time: 1716220563,
-            expiry_time: Date.now() / 1000 + 1000,
+            expiry_time: mockedNow + 1000,
             id: '917d1b48-305b-a2f4-5b9c-7fb1f2c6c145',
             is_expired: 0,
             is_forward_starting: 0,
@@ -71,7 +73,7 @@ const openPositions = [
             profit: -2.62,
             profit_percentage: -29.11,
             purchase_time: 1716220562,
-            shortcode: `CALL_1HZ100V_17.61_1716220562_${Date.now() / 1000 + 1000}F_S0P_0`,
+            shortcode: `CALL_1HZ100V_17.61_1716220562_${mockedNow + 1000}F_S0P_0`,
             status: 'open',
             transaction_ids: {
                 buy: 484286139408,
@@ -110,8 +112,8 @@ const openPositions = [
             current_spot: 681.71,
             current_spot_display_value: '681.71',
             current_spot_time: 1716220672,
-            date_expiry: Date.now() / 1000 + 1000,
-            date_settlement: Date.now() / 1000 + 1000,
+            date_expiry: mockedNow + 1000,
+            date_settlement: mockedNow + 1000,
             date_start: 1716220583,
             display_name: 'Volatility 100 (1s) Index',
             entry_spot: 682.23,
@@ -119,7 +121,7 @@ const openPositions = [
             entry_tick: 682.23,
             entry_tick_display_value: '682.23',
             entry_tick_time: 1716220584,
-            expiry_time: Date.now() / 1000 + 1000,
+            expiry_time: mockedNow + 1000,
             id: '917d1b48-305b-a2f4-5b9c-7fb1f2c6c145',
             is_expired: 0,
             is_forward_starting: 0,
@@ -143,7 +145,7 @@ const openPositions = [
             profit: -0.1,
             profit_percentage: -1.11,
             purchase_time: 1716220583,
-            shortcode: `MULTUP_1HZ100V_9.00_10_1716220583_${Date.now() / 1000 + 1000}_60m_0.00_N1`,
+            shortcode: `MULTUP_1HZ100V_9.00_10_1716220583_${mockedNow + 1000}_60m_0.00_N1`,
             status: 'open',
             transaction_ids: {
                 buy: 484286215128,
@@ -189,8 +191,8 @@ const openPositions = [
             current_spot_high_barrier: '683.016',
             current_spot_low_barrier: '682.424',
             current_spot_time: 1716220720,
-            date_expiry: Date.now() / 1000 + 1000,
-            date_settlement: Date.now() / 1000 + 1000,
+            date_expiry: mockedNow + 1000,
+            date_settlement: mockedNow + 1000,
             date_start: 1716220710,
             display_name: 'Volatility 100 (1s) Index',
             entry_spot: 682.58,
@@ -198,7 +200,7 @@ const openPositions = [
             entry_tick: 682.58,
             entry_tick_display_value: '682.58',
             entry_tick_time: 1716220711,
-            expiry_time: Date.now() / 1000 + 1000,
+            expiry_time: mockedNow + 1000,
             growth_rate: 0.01,
             high_barrier: '683.046',
             id: '917d1b48-305b-a2f4-5b9c-7fb1f2c6c145',
@@ -306,15 +308,16 @@ describe('ContractCard', () => {
         currency: 'USD',
         hasActionButtons: true,
         isSellRequested: false,
-        redirectTo: getContractPath(openPositions[0].contract_info.contract_id),
-        serverTime: toMoment(Date.now() / 1000),
+        serverTime: toMoment(mockedNow),
     };
     const mockedContractCard = (props = mockProps) => (
         <Router history={history}>
             <ContractCard {...props} />
         </Router>
     );
-
+    beforeEach(() => {
+        history.push('/');
+    });
     it('should not render component if contractInfo prop is empty/missing contract_type', () => {
         const { container } = render(mockedContractCard({ ...mockProps, contractInfo: {} }));
 
@@ -433,5 +436,20 @@ describe('ContractCard', () => {
         userEvent.click(card);
         expect(mockedOnClick).toHaveBeenCalledTimes(1);
         expect(history.location.pathname).toBe(redirectTo);
+    });
+    it('should call onClick when a card is clicked, but should not redirect anywhere if redirectTo prop is missing', () => {
+        const mockedOnClick = jest.fn();
+        const redirectTo = getContractPath(Number(closedPositions[0].contract_info.contract_id));
+        render(
+            mockedContractCard({
+                ...mockProps,
+                contractInfo: closedPositions[0].contract_info,
+                onClick: mockedOnClick,
+            })
+        );
+        const card = screen.getByText('Turbos Up');
+        userEvent.click(card);
+        expect(mockedOnClick).toHaveBeenCalledTimes(1);
+        expect(history.location.pathname).not.toBe(redirectTo);
     });
 });

--- a/packages/trader/src/AppV2/Components/ContractCard/contract-card-list.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/contract-card-list.tsx
@@ -52,7 +52,7 @@ const ContractCardList = ({
                         isSellRequested={(position as TPortfolioPosition).is_sell_requested}
                         onCancel={() => id && onClickCancel?.(id)}
                         onClose={() => id && onClickSell?.(id)}
-                        redirectTo={getContractPath(Number(id))}
+                        redirectTo={id ? getContractPath(id) : ''}
                         {...rest}
                     />
                 );

--- a/packages/trader/src/AppV2/Components/ContractCard/contract-card.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/contract-card.tsx
@@ -27,10 +27,10 @@ type TContractCardProps = TContractCardStatusTimerProps & {
     currency?: string;
     hasActionButtons?: boolean;
     isSellRequested?: boolean;
-    onClick?: (e?: React.MouseEvent<HTMLAnchorElement>) => void;
+    onClick?: (e?: React.MouseEvent<HTMLAnchorElement | HTMLDivElement>) => void;
     onCancel?: (e?: React.MouseEvent<HTMLButtonElement>) => void;
     onClose?: (e?: React.MouseEvent<HTMLButtonElement>) => void;
-    redirectTo: string;
+    redirectTo?: string;
     serverTime?: TRootStore['common']['server_time'];
 };
 
@@ -78,6 +78,7 @@ const ContractCard = ({
     const validToSell = isValidToSell(contractInfo as TContractInfo) && !isSellRequested;
     const isCancelButtonPressed = isSellRequested && isCanceling;
     const isCloseButtonPressed = isSellRequested && isClosing;
+    const Component = redirectTo ? BinaryLink : 'div';
 
     const handleSwipe = (direction: string) => {
         const isLeft = direction === DIRECTION.LEFT;
@@ -111,7 +112,7 @@ const ContractCard = ({
     if (!contract_type) return null;
     return (
         <div className={clsx(`${className}-wrapper`, { deleted: isDeleted })}>
-            <BinaryLink
+            <Component
                 {...(hasActionButtons ? swipeHandlers : {})}
                 className={clsx(className, {
                     'show-buttons': shouldShowButtons,
@@ -183,7 +184,7 @@ const ContractCard = ({
                         </button>
                     </div>
                 )}
-            </BinaryLink>
+            </Component>
         </div>
     );
 };

--- a/packages/trader/src/AppV2/Components/ContractCard/contract-cards-sections.tsx
+++ b/packages/trader/src/AppV2/Components/ContractCard/contract-cards-sections.tsx
@@ -24,24 +24,29 @@ const ContractCardsSections = ({ isLoadingMore, hasBottomMargin, positions }: TC
 
     if (!positions?.length) return null;
     return (
-        <div
-            className={clsx('contract-cards-sections', hasBottomMargin && 'contract-cards-sections--has-bottom-margin')}
-        >
-            {uniqueDates.map(date => (
-                <div className='contract-cards-section' key={date}>
-                    <Text as='p' className='contract-cards-section__title' bold size='sm'>
-                        {date}
-                    </Text>
-                    <ContractCardList
-                        positions={positions.filter(position => {
-                            const purchaseTime = position.contract_info.purchase_time_unix;
-                            return purchaseTime && formatTime(purchaseTime) === date;
-                        })}
-                    />
-                    {isLoadingMore && <Loading is_fullscreen={false} />}
-                </div>
-            ))}
-        </div>
+        <React.Fragment>
+            <div
+                className={clsx(
+                    'contract-cards-sections',
+                    hasBottomMargin && 'contract-cards-sections--has-bottom-margin'
+                )}
+            >
+                {uniqueDates.map(date => (
+                    <div className='contract-cards-section' key={date}>
+                        <Text as='p' className='contract-cards-section__title' bold size='sm'>
+                            {date}
+                        </Text>
+                        <ContractCardList
+                            positions={positions.filter(position => {
+                                const purchaseTime = position.contract_info.purchase_time_unix;
+                                return purchaseTime && formatTime(purchaseTime) === date;
+                            })}
+                        />
+                    </div>
+                ))}
+            </div>
+            {isLoadingMore && <Loading is_fullscreen={false} />}
+        </React.Fragment>
     );
 };
 


### PR DESCRIPTION
## Changes:

- to fix the loader shown upon infinite scroll in Closed tab
- to make `redirectTo` prop optional in `ContractCard` component
